### PR TITLE
Fix authentication middleware - resolve login redirect issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.0",
     "@tanstack/react-query": "^5.80.6",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,40 +1,55 @@
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+import { createServerClient } from '@supabase/ssr'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export async function middleware(req: NextRequest) {
-  const res = NextResponse.next()
-  
-  try {
-    // Create a Supabase client configured to use cookies
-    const supabase = createMiddlewareClient({ req, res })
-    
-    // Refresh session if expired - required for Server Components
-    const { data: { session }, error } = await supabase.auth.getSession()
-    
-    if (error) {
-      console.error('Middleware auth error:', error)
+  let supabaseResponse = NextResponse.next({
+    request: req,
+  })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return req.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => req.cookies.set(name, value))
+          supabaseResponse = NextResponse.next({
+            request: req,
+          })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          )
+        },
+      },
     }
-    
-    // For authenticated routes, redirect to login if no session
-    const protectedRoutes = ['/dashboard', '/training', '/campaigns', '/team', '/analytics', '/contacts', '/settings']
-    const isProtectedRoute = protectedRoutes.some(route => req.nextUrl.pathname.startsWith(route))
-    
-    if (isProtectedRoute && !session) {
-      const redirectUrl = req.nextUrl.clone()
-      redirectUrl.pathname = '/login'
-      redirectUrl.searchParams.set('redirectTo', req.nextUrl.pathname)
-      return NextResponse.redirect(redirectUrl)
-    }
-    
-    // Don't set CSP headers here - they're already set in next.config.js
-    // Just return the response with refreshed session
-    return res
-  } catch (error) {
-    console.error('Middleware error:', error)
-    // Don't crash the middleware, just continue
-    return res
+  )
+
+  // IMPORTANT: Avoid writing any logic between createServerClient and
+  // supabase.auth.getUser(). A simple mistake could make your server
+  // vulnerable to CSRF attacks.
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  // Protected routes that require authentication
+  const protectedRoutes = ['/dashboard', '/training', '/campaigns', '/team', '/analytics', '/contacts', '/settings']
+  const isProtectedRoute = protectedRoutes.some(route => req.nextUrl.pathname.startsWith(route))
+
+  if (isProtectedRoute && !user) {
+    // No user, redirect to login
+    const redirectUrl = req.nextUrl.clone()
+    redirectUrl.pathname = '/login'
+    redirectUrl.searchParams.set('redirectTo', req.nextUrl.pathname)
+    return NextResponse.redirect(redirectUrl)
   }
+
+  // IMPORTANT: You *must* return the supabaseResponse object as it contains the modified cookies.
+  return supabaseResponse
 }
 
 // Configure which routes the middleware should run on


### PR DESCRIPTION
## Summary

This PR fixes the authentication issue that was preventing users from logging in. The problem was caused by a mismatch between Supabase packages.

### Issue
The middleware was using the deprecated `@supabase/auth-helpers-nextjs` package with `createMiddlewareClient`, while the rest of the app uses the newer `@supabase/ssr` package with `createServerClient`. This mismatch was causing authentication failures and redirect loops.

### Changes Made

1. **Updated middleware.ts**:
   - Replaced `createMiddlewareClient` from `@supabase/auth-helpers-nextjs` with `createServerClient` from `@supabase/ssr`
   - Updated the cookie handling to match the new SSR pattern
   - Properly returns the modified response object with cookies

2. **Updated package.json**:
   - Removed the deprecated `@supabase/auth-helpers-nextjs` dependency
   - Kept only the modern `@supabase/ssr` package

### Testing
After these changes:
- Authentication should work properly
- Users should be able to log in without redirect loops
- The auth timeout error should be resolved

### Important Notes
- The middleware now uses `getUser()` instead of `getSession()` for better security
- Cookie handling follows the official Supabase SSR pattern
- All authentication methods are now consistent across the app