### PR TITLE
Fix Netlify build error - add missing sharp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-hot-toast": "^2.5.2",
     "recharts": "^2.15.3",
     "resend": "^4.5.2",
+    "sharp": "^0.33.5",
     "tailwindcss": "^3.4.0",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
## Summary

This PR fixes the Netlify build error by adding the missing `sharp` dependency.

### Issue
The Netlify deployment was failing with the error that the `sharp` package was missing. This package is required by Next.js for image optimization during the build process.

### Solution
Added `sharp` version `^0.33.5` to the dependencies in `package.json`.

### Changes
- Added `sharp: "^0.33.5"` to dependencies in package.json

This should resolve the build error and allow the deployment to complete successfully.